### PR TITLE
Auto close sidebar on mobile

### DIFF
--- a/app/state/reducers/uiReducer.js
+++ b/app/state/reducers/uiReducer.js
@@ -4,18 +4,29 @@ function isMobile() {
   return window.innerWidth <= 768;
 }
 
-const initialState = {
-  sidebar: {
-    collapsed: isMobile(),
-  },
-};
+function getInitialState() {
+  return {
+    sidebar: {
+      collapsed: isMobile(),
+    },
+  };
+}
 
-export default function uiReducer(state = initialState, action) {
+function toggleSidebar(state, collapsed) {
+  return Object.assign({}, state, {
+    sidebar: Object.assign({}, state.sidebar, { collapsed }),
+  });
+}
+
+export default function uiReducer(state = getInitialState(), action) {
   switch (action.type) {
     case actionTypes.TOGGLE_SIDEBAR:
-      return Object.assign({}, state, {
-        sidebar: Object.assign({}, state.sidebar, { collapsed: !state.sidebar.collapsed }),
-      });
+      return toggleSidebar(state, !state.sidebar.collapsed);
+    case actionTypes.CHANGE_CITY_FILTER:
+    case actionTypes.CHANGE_POSTAL_CODE_FILTER:
+    case actionTypes.CHANGE_OWNER_FILTER:
+      if (isMobile()) return toggleSidebar(state, true);
+      return state;
     default:
       return state;
   }

--- a/app/state/reducers/uiReducer.spec.js
+++ b/app/state/reducers/uiReducer.spec.js
@@ -1,5 +1,7 @@
 import { expect } from 'chai';
+import simple from 'simple-mock';
 
+import uiActions from 'actions/uiActions';
 import reducer from './uiReducer';
 
 function getSidebarState(extra) {
@@ -9,24 +11,71 @@ function getSidebarState(extra) {
 }
 
 describe('state/reducers/uiReducer', () => {
-  it('returns initial state', () => {
-    const actual = reducer(undefined, { type: 'NOOP' });
-    expect(actual).to.deep.equal({
-      sidebar: {
-        collapsed: window.innerWidth <= 768,
-      },
+  function createTests({ isMobile }) {
+    it('returns initial state', () => {
+      const actual = reducer(undefined, { type: 'NOOP' });
+      expect(actual).to.deep.equal({ sidebar: { collapsed: isMobile } });
     });
+
+    describe('TOGGLE_SIDEBAR', () => {
+      it('toggles from true to false', () => {
+        const actual = reducer(getSidebarState({ collapsed: true }), { type: 'TOGGLE_SIDEBAR' });
+        expect(actual.sidebar).to.deep.equal({ collapsed: false });
+      });
+
+      it('toggles from false to true', () => {
+        const actual = reducer(getSidebarState({ collapsed: false }), { type: 'TOGGLE_SIDEBAR' });
+        expect(actual.sidebar).to.deep.equal({ collapsed: true });
+      });
+    });
+
+    const testName = isMobile ? 'hides sidebar' : 'does not hide sidebar';
+
+    describe('CHANGE_CITY_FILTER', () => {
+      it(testName, () => {
+        const actual = reducer(getSidebarState({ collapsed: false }), uiActions.changeCityFilter('Espoo'));
+        expect(actual.sidebar).to.deep.equal({ collapsed: isMobile });
+      });
+    });
+
+    describe('CHANGE_POSTAL_CODE_FILTER', () => {
+      it(testName, () => {
+        const initial = getSidebarState({ collapsed: false });
+        const actual = reducer(initial, uiActions.changePostalCodeFilter([]));
+        expect(actual.sidebar).to.deep.equal({ collapsed: isMobile });
+      });
+    });
+
+    describe('CHANGE_OWNER_FILTER', () => {
+      it(testName, () => {
+        const initial = getSidebarState({ collapsed: false });
+        const actual = reducer(initial, uiActions.changeOwnerFilter([]));
+        expect(actual.sidebar).to.deep.equal({ collapsed: isMobile });
+      });
+    });
+  }
+
+  describe('on mobile', () => {
+    before(() => {
+      simple.mock(window, 'innerWidth', 768);
+    });
+
+    after(() => {
+      simple.restore();
+    });
+
+    createTests({ isMobile: true });
   });
 
-  describe('TOGGLE_SIDEBAR', () => {
-    it('toggles from true to false', () => {
-      const actual = reducer(getSidebarState({ collapsed: true }), { type: 'TOGGLE_SIDEBAR' });
-      expect(actual.sidebar).to.deep.equal({ collapsed: false });
+  describe('on desktop', () => {
+    before(() => {
+      simple.mock(window, 'innerWidth', 769);
     });
 
-    it('toggles from false to true', () => {
-      const actual = reducer(getSidebarState({ collapsed: false }), { type: 'TOGGLE_SIDEBAR' });
-      expect(actual.sidebar).to.deep.equal({ collapsed: true });
+    after(() => {
+      simple.restore();
     });
+
+    createTests({ isMobile: false });
   });
 });


### PR DESCRIPTION
On some mobile devices the sidebar hides the entire map and users didn't notice anything was happening when the filters changed.